### PR TITLE
New example: use the settings hooks to provide a different color palette for blocks depending on parent

### DIFF
--- a/use-settings-hook/README.md
+++ b/use-settings-hook/README.md
@@ -1,0 +1,3 @@
+Example of using the existing hooks to customize the editor to your liking. This provides a custom theme palette for paragraph blocks within the quote – any other paragraph block will have the default theme palette.
+
+Related: https://developer.wordpress.org/block-editor/how-to-guides/curating-the-editor-experience/

--- a/use-settings-hook/use-settings-hook.js
+++ b/use-settings-hook/use-settings-hook.js
@@ -1,0 +1,33 @@
+(function (wp) {
+    var addFilter = wp.hooks.addFilter;
+    var selectFrom = wp.data.select;
+    const blockEditorStore = 'core/block-editor';
+
+    addFilter(
+        'blockEditor.useSetting.before',
+        'example/useSetting.before',
+        (settingValue, settingName, clientId, blockName) => {
+            if (
+                settingName !== 'color.palette.theme' ||
+                blockName !== 'core/paragraph'
+            ) {
+                return settingValue;
+            }
+
+            const { getBlockParents, getBlockName } =
+                selectFrom(blockEditorStore);
+            const blockParents = getBlockParents(clientId, true);
+            const inQuote = blockParents.some(
+                (ancestorId) => getBlockName(ancestorId) === 'core/quote'
+            );
+            if (inQuote) {
+                const settings = selectFrom(blockEditorStore).getSettings();
+                return settings.__experimentalFeatures?.blocks?.['core/quote']?.[
+                    'core/paragraph'
+                ]?.color?.palette?.theme;
+            }
+
+            return settingValue;
+        }
+    );
+})(window.wp);

--- a/use-settings-hook/use-settings-hook.php
+++ b/use-settings-hook/use-settings-hook.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Plugin Name: Use Settings Hook
+ * Plugin URI: https://github.com/oandregal/understanding-gutenberg
+ * Description: Plugin to showcase how to hook into the block editor settings.
+ * Version: 0.0.1
+ */
+
+add_filter( 'block_editor_settings_all', function( $settings ) {
+	$settings['__experimentalFeatures']['blocks']['core/quote']['core/paragraph']['color']['palette']['theme'] = [
+		[ "color" => '#000', "name" => 'Black', "slug" => 'black' ],
+		[ "color" => '#fff', "name" => 'White', "slug" => 'white' ],
+	];
+	return $settings;
+} );
+
+// Register & enqueue block editor script.
+function use_settings_hook_plugin_register() {
+	wp_register_script(
+		'use_settings_hook_plugin_register',
+		plugins_url( 'use-settings-hook.js', __FILE__ ),
+		array( 'wp-data', 'wp-hooks' )
+	);
+}
+add_action( 'init', 'use_settings_hook_plugin_register' );
+
+function use_settings_hook_plugin_enqueue() {
+	wp_enqueue_script( 'use_settings_hook_plugin_register' );
+}
+add_action( 'enqueue_block_editor_assets', 'use_settings_hook_plugin_enqueue' );


### PR DESCRIPTION
This example uses the existing hooks for block editor settings (client side, and server side) to provide a different color palette depending on the block's parent:

- if the paragraph block is within a quote block, provide a two-color palette (black & white)
- otherwise, the paragraph block displays the theme defaults

https://github.com/oandregal/understanding-gutenberg/assets/583546/f17db263-7bd3-4f0e-befe-d372a12d9274

